### PR TITLE
Split ModelUnrest from ModelNonRev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ pll/Makefile
 pll/cmake_install.cmake
 pll/libpll.a
 pll_test/
-
+build/
 /Default-clang

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -20,4 +20,5 @@ ratefreeinvar.cpp
 modelcodon.cpp
 modelmorphology.cpp
 modelmixture.cpp
+modelunrest.cpp
 )

--- a/model/modelmixture.cpp
+++ b/model/modelmixture.cpp
@@ -1013,11 +1013,10 @@ ModelSubst* createModel(string model_str, ModelsBlock *models_block, StateFreqTy
 //			((ModelGTR*)model)->readRates(model_params);
 //		((ModelGTR*)model)->init(freq_type);
 //	} else
-	if (model_str == "UNREST") {
+	if (ModelNonRev::validModelName(model_str)) {
 		freq_type = FREQ_ESTIMATE;
-		//params.optimize_by_newton = false;
 		tree->optimize_by_newton = false;
-		model = new ModelNonRev(tree, model_params, count_rates);
+		model = ModelNonRev::getModelByName(model_str, tree, model_params, count_rates);
 		((ModelNonRev*)model)->init(freq_type);
 	} else if (tree->aln->seq_type == SEQ_BINARY) {
 		model = new ModelBIN(model_str.c_str(), model_params, freq_type, freq_params, tree, count_rates);

--- a/model/modelnonrev.h
+++ b/model/modelnonrev.h
@@ -31,7 +31,17 @@ The general non-reversible model
 class ModelNonRev : public ModelGTR
 {
 public:
-    ModelNonRev(PhyloTree *tree, string model_params, bool count_rates = true);
+    ModelNonRev(PhyloTree *tree);
+
+    /**
+     * Return a model of type given by model_name. (Will be some subclass of ModelNonRev.)
+     */
+    static ModelNonRev* getModelByName(string model_name, PhyloTree *tree, string model_params, bool count_rates);
+
+    /**
+     * true if model_name is the name of some known non-reversible model
+     */
+    static bool validModelName(string model_name);
 
     /** 
         save object into the checkpoint
@@ -108,6 +118,13 @@ public:
 
 protected:
 
+	/*
+	 * MDW:
+	 * I strongly object to the function naming here - it completely threw me.
+	 * a 'get' method should copy data from the object, and a 'set' method should
+	 * write data into the object. These are named completely the wrong way around!
+	 */
+
 	/**
 		this function is served for the multi-dimension optimization. It should pack the model parameters 
 		into a vector that is index from 1 (NOTE: not from 0)
@@ -123,7 +140,20 @@ protected:
 	*/
 	virtual bool getVariables(double *variables);
 
+	/**
+	 * Called from getVariables to update the rate matrix for the new
+	 * model parameters.
+	 */
+	virtual void setRates();
+
 	virtual void freeMem();
+
+	/**
+	    Model parameters - cached so we know when they change, and thus when
+	    recalculations are needed.
+
+	 */
+	double *model_parameters;
 
 	/**
 		unrestricted Q matrix. Note that Q is normalized to 1 and has row sums of 0.

--- a/model/modelunrest.cpp
+++ b/model/modelunrest.cpp
@@ -1,0 +1,56 @@
+/*
+ * modelunrest.cpp
+ *
+ *  Created on: 24/05/2016
+ *      Author: mdw2
+ */
+
+#include "modelunrest.h"
+
+ModelUnrest::ModelUnrest(PhyloTree *tree, string model_params, bool count_rates)
+	: ModelNonRev(tree)
+{
+	num_params = getNumRateEntries() - 1;
+	model_parameters = new double [num_params];
+	for (int i=0; i<= num_params; i++) model_parameters[i] = 1;
+	this->setRates();
+	/*
+	 * I'm not sure how to correctly handle count_rates, so for now I'm just
+	 * avoiding the problem. Actual IQTree programmers can fix this.
+	 * Whatever happens should leave model_parameters[] and rates[]
+	 * consistent with each other.
+	 */
+	if (count_rates)
+		cerr << "WARNING: count_rates=TRUE not implemented in ModelUnrest constructor -- ignored" << endl;
+		/* phylo_tree->aln->computeEmpiricalRateNonRev(rates); */
+	if (model_params != "") {
+		cerr << "WARNING: Supplying model params to constructor not yet properly implemented -- ignored" << endl;
+		// TODO: parse model_params into model_parameters, then call setRates().
+	}
+    name = "UNREST";
+    full_name = "Unrestricted model (non-reversible)";
+}
+
+/* static */ bool ModelUnrest::validModelName(string model_name) {
+	return (model_name == "UNREST");
+}
+
+void ModelUnrest::setBounds(double *lower_bound, double *upper_bound, bool *bound_check) {
+	int i, ndim = getNDim();
+
+	for (i = 1; i <= ndim; i++) {
+		lower_bound[i] = 0.01;
+		upper_bound[i] = 100.0;
+		bound_check[i] = false;
+	}
+}
+
+/*
+ * Set rates from model_parameters
+ */
+void ModelUnrest::setRates() {
+	// For UNREST, parameters are simply the off-diagonal rate matrix entries
+	// (except [4,3] = rates[11], which is constrained to be 1)
+	memcpy(rates, model_parameters, num_params*sizeof(double));
+	rates[num_params]=1;
+}

--- a/model/modelunrest.h
+++ b/model/modelunrest.h
@@ -1,0 +1,22 @@
+/*
+ * modelunrest.h
+ *
+ *  Created on: 24/05/2016
+ *      Author: Michael Woodhams
+ */
+
+#ifndef MODELUNREST_H_
+#define MODELUNREST_H_
+
+#include "modelnonrev.h"
+
+class ModelUnrest: public ModelNonRev {
+public:
+	ModelUnrest(PhyloTree *tree, string model_params, bool count_rates);
+	static bool validModelName(string model_name);
+	void setBounds(double *lower_bound, double *upper_bound, bool *bound_check);
+private:
+	void setRates();
+};
+
+#endif /* MODELUNREST_H_ */

--- a/ngs.cpp
+++ b/ngs.cpp
@@ -23,6 +23,7 @@
 */
 
 #include "ngs.h"
+#include "model/modelnonrev.h"
 //#include "modeltest_wrapper.h"
 
 /****************************************************************************
@@ -832,7 +833,12 @@ void reportNGSAnalysis(const char *file_name, Params &params, NGSAlignment &aln,
 
     tree.getModel()->getRateMatrix(rate_param);
 
-    if (tree.getModel()->name == "UNREST") {
+    /*
+     * This isn't a good way of doing it. Rather somewhere high up in the model heirarchy
+     * define a bool isSymmetric() method, which is true for time reversible models and
+     * not true for nonTR models. ! ModelGTR has 'half_matrix' member, which should do the job.
+     */
+    if (ModelNonRev::validModelName(tree.getModel()->name)) {
         for (i = 0, k=0; i < aln.num_states; i++)
             for (j = 0; j < aln.num_states; j++)
                 if (i != j)


### PR DESCRIPTION
Current functionality of ModelNonRev class split into ModelNonRev (general abstrct non-time reversable model class) and ModelUnrest (the 'unrestricted' or 'general Markov' model).

This commit is buggy: gets memory corruption errors. I don't yet know why.