### PR TITLE
Use FindBacktrace cmake module for greater portability.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,7 @@ check_function_exists (gettimeofday HAVE_GETTIMEOFDAY)
 check_function_exists (getrusage HAVE_GETRUSAGE)
 check_function_exists (GlobalMemoryStatusEx HAVE_GLOBALMEMORYSTATUSEX)
 check_function_exists (strndup HAVE_STRNDUP)
+find_package(Backtrace)
 
 # configure a header file to pass some of the CMake settings
 # to the source code
@@ -504,6 +505,11 @@ constrainttree.cpp constrainttree.h
 MPIHelper.cpp MPIHelper.h
 memslot.cpp memslot.h
 )
+
+if(Backtrace_FOUND)
+  include_directories(${Backtrace_INCLUDE_DIR})
+  target_link_libraries(iqtree ${Backtrace_LIBRARY})
+endif(Backtrace_FOUND)
 
 if (NOT IQTREE_FLAGS MATCHES "nozlib")
     find_package(ZLIB)

--- a/iqtree_config.h.in
+++ b/iqtree_config.h.in
@@ -12,3 +12,6 @@
 /*#cmakedefine HAVE_PCLOSE*/
 /* does the platform provide GlobalMemoryStatusEx functions? */
 #cmakedefine HAVE_GLOBALMEMORYSTATUSEX
+
+/* does the platform provide backtrace functions? */
+#cmakedefine Backtrace_FOUND

--- a/tools.cpp
+++ b/tools.cpp
@@ -22,14 +22,14 @@
 
 
 
-#if (defined(__GNUC__) || defined(__clang__)) && !defined(WIN32) && !defined(__CYGWIN__)
-#include <execinfo.h>
-#include <cxxabi.h>
-#endif
-
 #include "tools.h"
 #include "timeutil.h"
 #include "MPIHelper.h"
+
+#if defined(Backtrace_FOUND)
+#include <execinfo.h>
+#include <cxxabi.h>
+#endif
 
 VerboseMode verbose_mode;
 
@@ -4032,7 +4032,7 @@ int countPhysicalCPUCores() {
 
 /** Print a demangled stack backtrace of the caller function to FILE* out. */
 
-#if  defined(WIN32) || defined(__CYGWIN__) 
+#if  !defined(Backtrace_FOUND)
 
 // donothing for WIN32
 void print_stacktrace(ostream &out, unsigned int max_frames) {}
@@ -4163,7 +4163,7 @@ void print_stacktrace(ostream &out, unsigned int max_frames)
 
 }
 
-#endif // WIN32
+#endif // Backtrace_FOUND
 
 bool memcmpcpy(void * destination, const void * source, size_t num) {
     bool diff = (memcmp(destination, source, num) != 0);


### PR DESCRIPTION
Fix build on NetBSD where backtrace(3) is provided by execinfo library.

Successfully tested on NetBSD, Linux and MacOSX.

Thanks.