### PR TITLE
Fix MPI version build failure with gcc 5.4.0

### DIFF
--- a/MPIHelper.cpp
+++ b/MPIHelper.cpp
@@ -372,9 +372,7 @@ void MPIHelper::receiveTrees(bool fromAll, int maxNumTrees, TreeCollection &tree
             MPI_Recv(recvBuffer, numBytes, MPI_CHAR, status.MPI_SOURCE, status.MPI_TAG, MPI_COMM_WORLD, &status);
             ObjectStream os(recvBuffer, numBytes);
             if (status.MPI_TAG == STOP_TAG) {
-                stringstream stopMsg;
-                stopMsg << os.getObjectData();
-                cout << stopMsg << endl;
+                cout <<  os.getObjectData() << endl;
                 MPI_Finalize();
                 exit(0);
             }


### PR DESCRIPTION
Hi,

Just wanted to compile the MPI version, but got a build failure with gcc 5.4.0 : 

/home/njoly/temp/IQ-TREE/MPIHelper.cpp: In member function 'void MPIHelper::receiveTrees(bool, int, TreeCollection&, int)':
/home/njoly/temp/IQ-TREE/MPIHelper.cpp:377:22: error: no match for 'operator<<' (operand types are 'std::ostream {aka std::basic_ostream<char>}' and 'std::stringstream {aka std::__cxx11::basic_stringstream<char>}')
                 cout << stopMsg << endl;

AFAIK, os.getObjectData() returns type is "char *", so no need to have an intermediate "stringstream" variable to store data before display.