### PR TITLE
Show more precision in log likelihood with --show-lh

### DIFF
--- a/model/modelfactory.cpp
+++ b/model/modelfactory.cpp
@@ -1176,9 +1176,17 @@ double ModelFactory::optimizeParameters(int fixed_len, bool write_info,
     cur_lh = tree->computeLikelihood();
     tree->setCurScore(cur_lh);
     if (verbose_mode >= VB_MED || write_info) {
-	int p = cout.precision(17);
+	int p = -1;
+
+	// SET precision to 17 (temporarily)
+	if (verbose_mode >= VB_DEBUG) p = cout.precision(17);
+
+	// PRINT Log-Likelihood
 	cout << "1. Initial log-likelihood: " << cur_lh << endl;
-	cout.precision(p);
+
+	// RESTORE previous precision
+	if (verbose_mode >= VB_DEBUG) cout.precision(p);
+
         if (verbose_mode >= VB_MAX) {
             tree->printTree(cout);
             cout << endl;

--- a/model/modelfactory.cpp
+++ b/model/modelfactory.cpp
@@ -1175,8 +1175,10 @@ double ModelFactory::optimizeParameters(int fixed_len, bool write_info,
     // no optimization of branch length in the first round
     cur_lh = tree->computeLikelihood();
     tree->setCurScore(cur_lh);
-	if (verbose_mode >= VB_MED || write_info) {
-		cout << "1. Initial log-likelihood: " << cur_lh << endl;
+    if (verbose_mode >= VB_MED || write_info) {
+	int p = cout.precision(17);
+	cout << "1. Initial log-likelihood: " << cur_lh << endl;
+	cout.precision(p);
         if (verbose_mode >= VB_MAX) {
             tree->printTree(cout);
             cout << endl;


### PR DESCRIPTION
This makes it possible for testiphy to test IQ-Tree correctly.

Its possible that a precision of 16 gives all the digits, but with
rounding and such its possible you need 17.