### PR TITLE
make terraphast compatible with C++11

### DIFF
--- a/terraphast/CMakeLists.txt
+++ b/terraphast/CMakeLists.txt
@@ -186,7 +186,7 @@ if(TERRAPHAST_BUILD_TESTS)
 	set(terraces_targets ${terraces_targets} unittests)
 endif()
 
-set_target_properties(${terraces_targets} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON)
+set_target_properties(${terraces_targets} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
 
 #####################################################################
 # set platform-specific options, include platform-specific files

--- a/terraphast/lib/constraints.cpp
+++ b/terraphast/lib/constraints.cpp
@@ -21,9 +21,10 @@ std::ostream& operator<<(std::ostream& stream, utils::named_output<constraints, 
 
 constraints compute_constraints(const std::vector<tree>& trees) {
 	constraints result;
-	auto num_nodes = (*std::max_element(trees.begin(), trees.end(), [](auto& a, auto& b) {
-		                 return a.size() < b.size();
-		         })).size();
+	auto num_nodes =
+	        (*std::max_element(trees.begin(), trees.end(), [](const tree& a, const tree& b) {
+		        return a.size() < b.size();
+		})).size();
 	std::vector<std::pair<index, index>> outermost_nodes(num_nodes, {none, none});
 
 	for (auto& t : trees) {
@@ -75,7 +76,7 @@ index deduplicate_constraints(constraints& in_c) {
 	for (auto& c : in_c) {
 		c = {std::min(c.left, c.shared), std::max(c.left, c.shared), c.right};
 	}
-	std::sort(in_c.begin(), in_c.end(), [](auto a, auto b) {
+	std::sort(in_c.begin(), in_c.end(), [](constraint a, constraint b) {
 		return std::tie(a.left, a.shared, a.right) < std::tie(b.left, b.shared, b.right);
 	});
 	auto it = std::unique(in_c.begin(), in_c.end());

--- a/terraphast/lib/multitree_impl.hpp
+++ b/terraphast/lib/multitree_impl.hpp
@@ -2,21 +2,33 @@
 #define MULTITREE_IMPL_HPP
 
 #include "multitree.hpp"
+
 #include <memory>
 
 namespace terraces {
 namespace multitree_impl {
 
 template <typename T>
+struct array_deleter {
+	void operator()(T* ptr) { delete[] ptr; }
+};
+
+template <typename T>
+std::unique_ptr<T[], array_deleter<T>> make_unique_array(std::size_t size) {
+	// this may leak memory if allocation or construction of a T fails
+	return std::unique_ptr<T[], array_deleter<T>>{new T[size]};
+}
+
+template <typename T>
 class storage_block {
 private:
-	std::unique_ptr<T[]> begin;
+	std::unique_ptr<T[], array_deleter<T>> begin;
 	index size;
 	index max_size;
 
 public:
 	storage_block(index max_size)
-	        : begin{std::make_unique<T[]>(max_size)}, size{0}, max_size{max_size} {}
+	        : begin{make_unique_array<T>(max_size)}, size{0}, max_size{max_size} {}
 
 	bool has_space(index required = 1) { return size + required <= max_size; }
 

--- a/terraphast/lib/rooting.cpp
+++ b/terraphast/lib/rooting.cpp
@@ -70,7 +70,7 @@ std::vector<bool> root_split(const tree& t, index num_leaves) {
 	std::vector<bool> split(num_leaves);
 	auto root = t[0];
 	foreach_preorder(t,
-	                 [&](auto i) {
+	                 [&](index i) {
 		                 auto node = t[i];
 		                 if (is_leaf(node)) {
 			                 split[node.taxon()] = true;
@@ -103,7 +103,7 @@ tree reroot_at_node(const tree& t, index node_idx) {
 	auto next = t[cur].parent();
 	while (next != 0) {
 		copy_reversed(t, out, prev, cur, next);
-		prev = std::exchange(cur, std::exchange(next, t[next].parent()));
+		prev = utils::exchange(cur, utils::exchange(next, t[next].parent()));
 	}
 
 	// everything on the opposite side of the original root is unchanged
@@ -138,7 +138,7 @@ void reroot_at_taxon_inplace(tree& t, index comp_taxon) {
 		if (t[p].lchild() == cur) {
 			std::swap(t[p].lchild(), t[p].rchild());
 		}
-		cur = std::exchange(p, t[p].parent());
+		cur = utils::exchange(p, t[p].parent());
 	}
 	// second: move the root down right until we meet root_leaf
 	auto& li = t[0].lchild();

--- a/terraphast/lib/stack_allocator.hpp
+++ b/terraphast/lib/stack_allocator.hpp
@@ -12,12 +12,11 @@
 namespace terraces {
 namespace utils {
 
-class array_deleter {
-public:
+struct char_array_deleter {
 	void operator()(char* ptr) { ::operator delete[](static_cast<void*>(ptr)); }
 };
 
-using char_buffer = std::unique_ptr<char[], array_deleter>;
+using char_buffer = std::unique_ptr<char[], char_array_deleter>;
 
 class free_list {
 public:

--- a/terraphast/lib/trees.cpp
+++ b/terraphast/lib/trees.cpp
@@ -65,7 +65,7 @@ std::vector<index> postorder(const tree& t) {
 }
 
 void print_tree_dot(const tree& t, const name_map& n, std::ostream& stream, bool rooted) {
-	auto nop = [](auto) {};
+	auto nop = [](index) {};
 	std::string edge = rooted ? " -> " : " -- ";
 	auto node_cb = [&](index node) {
 		stream << node << " [shape=point];\n";

--- a/terraphast/lib/union_find.cpp
+++ b/terraphast/lib/union_find.cpp
@@ -1,4 +1,5 @@
 #include "union_find.hpp"
+#include "utils.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -18,7 +19,7 @@ index union_find::find(index x) {
 		root = m_parent[root];
 	}
 	while (x != root) {
-		x = std::exchange(m_parent[x], root);
+		x = utils::exchange(m_parent[x], root);
 	}
 	assert(is_representative(root) && root < m_parent.size());
 	return root;

--- a/terraphast/lib/utils.hpp
+++ b/terraphast/lib/utils.hpp
@@ -9,6 +9,13 @@
 namespace terraces {
 namespace utils {
 
+template <class T, class U = T>
+T exchange(T& obj, U&& new_value) {
+	T old_value = std::move(obj);
+	obj = std::forward<U>(new_value);
+	return old_value;
+}
+
 template <typename Iterator>
 Iterator skip_ws(Iterator it, Iterator last) {
 	while (it != last and std::isspace(*it)) {

--- a/terraphast/test/advanced.cpp
+++ b/terraphast/test/advanced.cpp
@@ -159,7 +159,7 @@ TEST_CASE("advanced_results", "[advanced-api]") {
 	                    "(s5,((s4,((s2,s3),s6)),s1));\n"
 	                    "(s5,(((s4,(s3,s6)),s2),s1));\n");
 	std::stringstream ss2;
-	enumerate_terrace(d3, [&](auto& tree) { ss2 << as_newick(tree, m3.names) << '\n'; });
+	enumerate_terrace(d3, [&](const tree& t) { ss2 << as_newick(t, m3.names) << '\n'; });
 	CHECK(ss.str() == ss2.str());
 }
 

--- a/terraphast/test/union_find.cpp
+++ b/terraphast/test/union_find.cpp
@@ -34,7 +34,7 @@ TEST_CASE("union_find::make_bipartition", "[union_find]") {
 	std::vector<bool> b1{1, 0, 1, 1, 0, 1, 0, 0};
 	std::vector<bool> b2{0, 1, 1, 1, 0, 0, 0, 0};
 	std::vector<bool> b3{1, 1, 1, 1, 1, 1, 1, 1};
-	auto check = [&](const auto& vec) {
+	auto check = [&](const std::vector<bool>& vec) {
 		auto uf = union_find::make_bipartition(vec, alloc);
 		auto i0 = std::distance(vec.begin(), std::find(vec.begin(), vec.end(), 0));
 		auto i1 = std::distance(vec.begin(), std::find(vec.begin(), vec.end(), 1));


### PR DESCRIPTION
This merge request basically contains the commits [50ac6d9](https://github.com/upsj/terraphast-one/commit/50ac6d9947c7780623c8b8f49ed71650b2b1817f), [bf372ae](https://github.com/upsj/terraphast-one/commit/bf372aec319d064328646eadd553b48482aa1e60) and [9254d27](https://github.com/upsj/terraphast-one/commit/9254d27521ad81eb08c4913218308ea01478a29b) from the stand-alone repository

Except for minor changes in memory management for the multitree generation, there should be no functional changes.